### PR TITLE
Removing outdated installation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,5 @@ This is official [Homebrew](https://brew.sh) tap for [NGINX Unit](https://unit.n
 
 Or `brew tap nginx/unit` and then `brew install <formula>`.
 
-Or install via URL (which will not receive updates):
-
-```
-brew install https://raw.githubusercontent.com/nginx/homebrew-unit/master/Formula/<formula>.rb
-```
-
 ## Documentation
 `brew help`, `man brew` or check [Homebrew's documentation](https://docs.brew.sh).


### PR DESCRIPTION
Homebrew doesn't allow to install formula using URL anymore:

```
$ brew install https://raw.githubusercontent.com/nginx/homebrew-unit/master/Formula/unit.rb
Error: Invalid usage: Non-checksummed download of unit formula file from an arbitrary URL is unsupported! 
```