### PR TITLE
Use git for head builds over hg

### DIFF
--- a/Formula/unit-java.rb
+++ b/Formula/unit-java.rb
@@ -3,7 +3,7 @@ class UnitJava < Formula
   homepage "https://unit.nginx.org"
   url "https://unit.nginx.org/download/unit-1.31.1.tar.gz"
   sha256 "9df604d49cb57ac0103202efb0f9373e3e48a7dd888c94af10d4f96ccded7d71"
-  head "https://hg.nginx.org/unit", using: :hg
+  head "https://github.com/nginx/unit.git", branch: "master"
 
   depends_on "openjdk@11"
   depends_on "openssl"

--- a/Formula/unit-perl.rb
+++ b/Formula/unit-perl.rb
@@ -3,7 +3,7 @@ class UnitPerl < Formula
   homepage "https://unit.nginx.org"
   url "https://unit.nginx.org/download/unit-1.31.1.tar.gz"
   sha256 "9df604d49cb57ac0103202efb0f9373e3e48a7dd888c94af10d4f96ccded7d71"
-  head "https://hg.nginx.org/unit", using: :hg
+  head "https://github.com/nginx/unit.git", branch: "master"
 
   depends_on "openssl"
   depends_on "perl"

--- a/Formula/unit-php.rb
+++ b/Formula/unit-php.rb
@@ -3,7 +3,7 @@ class UnitPhp < Formula
   homepage "https://unit.nginx.org"
   url "https://unit.nginx.org/download/unit-1.31.1.tar.gz"
   sha256 "9df604d49cb57ac0103202efb0f9373e3e48a7dd888c94af10d4f96ccded7d71"
-  head "https://hg.nginx.org/unit", using: :hg
+  head "https://github.com/nginx/unit.git", branch: "master"
 
   depends_on "openssl"
   depends_on "php-embed"

--- a/Formula/unit-python.rb
+++ b/Formula/unit-python.rb
@@ -3,7 +3,7 @@ class UnitPython < Formula
   homepage "https://unit.nginx.org"
   url "https://unit.nginx.org/download/unit-1.31.1.tar.gz"
   sha256 "9df604d49cb57ac0103202efb0f9373e3e48a7dd888c94af10d4f96ccded7d71"
-  head "https://hg.nginx.org/unit", using: :hg
+  head "https://github.com/nginx/unit.git", branch: "master"
 
   depends_on maximum_macos: :big_sur
   depends_on "openssl"

--- a/Formula/unit-python3.rb
+++ b/Formula/unit-python3.rb
@@ -3,8 +3,7 @@ class UnitPython3 < Formula
   homepage "https://unit.nginx.org"
   url "https://unit.nginx.org/download/unit-1.31.1.tar.gz"
   sha256 "9df604d49cb57ac0103202efb0f9373e3e48a7dd888c94af10d4f96ccded7d71"
-  head "https://hg.nginx.org/unit", using: :hg
-
+  head "https://github.com/nginx/unit.git", branch: "master"
   depends_on "openssl"
   depends_on "python3"
   depends_on "unit@1.31.1"

--- a/Formula/unit-ruby.rb
+++ b/Formula/unit-ruby.rb
@@ -3,7 +3,7 @@ class UnitRuby < Formula
   homepage "https://unit.nginx.org"
   url "https://unit.nginx.org/download/unit-1.31.1.tar.gz"
   sha256 "9df604d49cb57ac0103202efb0f9373e3e48a7dd888c94af10d4f96ccded7d71"
-  head "https://hg.nginx.org/unit", using: :hg
+  head "https://github.com/nginx/unit.git", branch: "master"
 
   depends_on "openssl"
   depends_on "ruby"

--- a/Formula/unit-wasm.rb
+++ b/Formula/unit-wasm.rb
@@ -3,7 +3,7 @@ class UnitWasm < Formula
   homepage "https://unit.nginx.org"
   url "https://unit.nginx.org/download/unit-1.31.1.tar.gz"
   sha256 "9df604d49cb57ac0103202efb0f9373e3e48a7dd888c94af10d4f96ccded7d71"
-  head "https://hg.nginx.org/unit", using: :hg
+  head "https://github.com/nginx/unit.git", branch: "master"
 
   depends_on "openssl"
   depends_on "unit@1.31.1"

--- a/Formula/unit.rb
+++ b/Formula/unit.rb
@@ -3,7 +3,7 @@ class Unit < Formula
   homepage "https://unit.nginx.org"
   url "https://unit.nginx.org/download/unit-1.31.1.tar.gz"
   sha256 "9df604d49cb57ac0103202efb0f9373e3e48a7dd888c94af10d4f96ccded7d71"
-  head "https://hg.nginx.org/unit", using: :hg
+  head "https://github.com/nginx/unit.git", branch: "master"
 
   depends_on "openssl"
   depends_on "pcre2"


### PR DESCRIPTION
As per https://github.com/nginx/unit/issues/1051

Sets the `head` stanza to use the GitHub based git repository over hg.

This will be used when installed unit with the `--head` command, cloning the git repository instead of downloading the source from `unit.nginx.org`.

Tested locally on macOS 14.
