### PR TITLE
Separate PHP formulas & update PHP to latest version(s)

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -122,6 +122,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
+        php: [php, php@8.2]
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
@@ -129,4 +130,4 @@ jobs:
 
       - name: Build Unit PHP module
         run:
-          brew install --build-from-source Formula/unit-php.rb
+          brew install --build-from-source Formula/unit-${{ matrix.php }}.rb

--- a/Aliases/php-embed@8.2
+++ b/Aliases/php-embed@8.2
@@ -1,1 +1,0 @@
-../Formula/php-embed.rb

--- a/Formula/php-embed@8.2.rb
+++ b/Formula/php-embed@8.2.rb
@@ -1,10 +1,10 @@
-class PhpEmbed < Formula
+class PhpEmbedAT82 < Formula
   desc "PHP library for embedding in applications"
   homepage "https://www.php.net/"
   # Should only be updated if the new version is announced on the homepage, https://www.php.net/
-  url "https://www.php.net/distributions/php-8.3.2.tar.xz"
-  mirror "https://fossies.org/linux/www/php-8.3.2.tar.xz"
-  sha256 "4ffa3e44afc9c590e28dc0d2d31fc61f0139f8b335f11880a121b9f9b9f0634e"
+  url "https://www.php.net/distributions/php-8.2.15.tar.xz"
+  mirror "https://fossies.org/linux/www/php-8.2.15.tar.xz"
+  sha256 "eca5deac02d77d806838275f8a3024b38b35ac0a5d9853dcc71c6cbe3f1f8765"
   license "PHP-3.01"
 
   livecheck do
@@ -19,7 +19,7 @@ class PhpEmbed < Formula
     depends_on "re2c" => :build # required to generate PHP lexers
   end
 
-  depends_on "php"
+  depends_on "php@8.2"
 
   on_macos do
     # PHP build system incorrectly links system libraries

--- a/Formula/unit-php@8.2.rb
+++ b/Formula/unit-php@8.2.rb
@@ -1,0 +1,73 @@
+class UnitPhpAT82 < Formula
+  desc "PHP module for Unit application server"
+  homepage "https://unit.nginx.org"
+  url "https://unit.nginx.org/download/unit-1.31.1.tar.gz"
+  sha256 "9df604d49cb57ac0103202efb0f9373e3e48a7dd888c94af10d4f96ccded7d71"
+  head "https://github.com/nginx/unit.git", branch: "master"
+
+  depends_on "openssl"
+  depends_on "php-embed@8.2"
+  depends_on "unit@1.31.1"
+
+  def install
+    system "./configure",
+              "--prefix=#{prefix}",
+              "--sbindir=#{bin}",
+              "--logdir=#{var}/log",
+              "--log=#{var}/log/unit/unit.log",
+              "--runstatedir=#{var}/run",
+              "--pid=#{var}/run/unit/unit.pid",
+              "--control=unix:#{var}/run/unit/control.sock",
+              "--modules=#{HOMEBREW_PREFIX}/lib/unit/modules",
+              "--statedir=#{var}/state/unit",
+              "--tmpdir=/tmp",
+              "--openssl",
+              "--cc-opt=-I#{Formula["openssl"].opt_prefix}/include",
+              "--ld-opt=-L#{Formula["openssl"].opt_prefix}/lib"
+
+    inreplace "build/autoconf.data",
+        "NXT_MODULESDIR='#{HOMEBREW_PREFIX}/lib/unit/modules'",
+        "NXT_MODULESDIR='#{lib}/unit/modules'"
+
+    system "./configure", "php"
+    system "make", "php-install"
+  end
+
+  test do
+    require "socket"
+
+    server = TCPServer.new(0)
+    port = server.addr[1]
+    server.close
+
+    expected_output = "Hello world!"
+    (testpath/"unit.conf").write <<~EOS
+      {
+        "listeners": { "*:#{port}": { "pass": "applications/test" } },
+        "applications": {
+          "test": { "type": "php", "root": "#{testpath}" }
+        }
+      }
+    EOS
+    (testpath/"index.php").write <<~EOS
+      <?php print("#{expected_output}"); ?>
+    EOS
+    (testpath/"state/certs").mkpath
+
+    system "#{HOMEBREW_PREFIX}/bin/unitd", "--log", "#{testpath}/unit.log",
+                        "--control", "unix:#{testpath}/control.sock",
+                        "--pid", "#{testpath}/unit.pid",
+                        "--statedir", "#{testpath}/state"
+    sleep 3
+
+    pid = File.open(testpath/"unit.pid").gets.chop.to_i
+
+    system "curl", "-s", "--unix-socket", "#{testpath}/control.sock",
+                    "-X", "PUT",
+                    "-d", "@#{testpath}/unit.conf", "127.0.0.1/config"
+
+    assert_match expected_output, shell_output("curl -s 127.0.0.1:#{port}")
+  ensure
+    Process.kill("TERM", pid)
+  end
+end


### PR DESCRIPTION
Hi,
I'm sending the PR that reflects updates of an official PHP distribution:

moving PHP-8.2 into unit-php@8.2
upgrading unit-php to PHP-8.3
I also slightly cleaned up the php-embed and php-embed@8.2 formulas.