### PR TITLE
Unit-ruby: depend on ruby@3.

### DIFF
--- a/Formula/unit-ruby.rb
+++ b/Formula/unit-ruby.rb
@@ -6,7 +6,7 @@ class UnitRuby < Formula
   head "https://github.com/nginx/unit.git", branch: "master"
 
   depends_on "openssl"
-  depends_on "ruby"
+  depends_on "ruby@3"
   depends_on "unit@1.31.1"
 
   def install


### PR DESCRIPTION
ruby alias does not seem to be there anymore and we would like to use Ruby 3 anyway.