### PR TITLE
CI: check out core

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,8 @@ jobs:
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
+        with:
+          core: true
 
       - name: Cache Homebrew Bundler RubyGems
         id: cache


### PR DESCRIPTION
This is so brew audit can know about all possible upstream aliases.