### PR TITLE
Revert "Unit-ruby: depend on ruby@3."

### DIFF
--- a/Formula/unit-ruby.rb
+++ b/Formula/unit-ruby.rb
@@ -6,7 +6,7 @@ class UnitRuby < Formula
   head "https://github.com/nginx/unit.git", branch: "master"
 
   depends_on "openssl"
-  depends_on "ruby@3"
+  depends_on "ruby"
   depends_on "unit@1.31.1"
 
   def install


### PR DESCRIPTION
This reverts commit b495e9bd5eb1466c9054d6d11826d2a50b854a1e.

This is wrong, and does not fix the underlying issue.