### PR TITLE
Python 2: restrict to macOS.

### DIFF
--- a/Formula/unit-python.rb
+++ b/Formula/unit-python.rb
@@ -5,6 +5,7 @@ class UnitPython < Formula
   sha256 "4b5e9be3f3990fceabf06292c2b7853667aceb71fd8de5dc67cb7fb05d247a20"
   head "https://github.com/nginx/unit.git", branch: "master"
 
+  depends_on :macos
   depends_on maximum_macos: :big_sur
   depends_on "openssl"
   depends_on "unit@1.32.0"


### PR DESCRIPTION
Homebrew does not ship python 2, which makes the dependency wrong on Linux as it resolves to current Python 3.

Also, we already limit it to an older version of macOS (11 and older), which still ships Python 2.

Note that our "weekly" CI builds are using macOS 11 to build this formula.