### PR TITLE
[DRAFT] CI: build dependants from source

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,5 +34,5 @@ jobs:
 
       - run: brew test-bot --only-tap-syntax
 
-      - run: brew test-bot --only-formulae
+      - run: brew test-bot --build-dependents-from-source --only-formulae
         if: github.event_name == 'pull_request'

--- a/Formula/unit-perl.rb
+++ b/Formula/unit-perl.rb
@@ -3,6 +3,7 @@ class UnitPerl < Formula
   homepage "https://unit.nginx.org"
   url "https://unit.nginx.org/download/unit-1.32.0.tar.gz"
   sha256 "4b5e9be3f3990fceabf06292c2b7853667aceb71fd8de5dc67cb7fb05d247a20"
+  revision 1
   head "https://github.com/nginx/unit.git", branch: "master"
 
   depends_on "openssl"


### PR DESCRIPTION
This fixes a CI test problem when one of the formulas is updated, but the main one, e.g. unit isnt.  Previous behaviour is to skip checks which is erroneous since we don't check if the actual change is OK.
