### PR TITLE
CI: Figure out if we need to build dependencies on pull requests.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,5 +34,12 @@ jobs:
 
       - run: brew test-bot --only-tap-syntax
 
-      - run: brew test-bot --only-formulae
+      - run: brew test-bot --only-formulae-detect
+        id: formulae-detect
+
+      - run:
+          brew test-bot --only-formulae --testing-formulae=${{ env.NEED_PHP_EMBED }}${{ env.NEED_UNIT }}${{ steps.formulae-detect.outputs.testing_formulae }}
+        env:
+          NEED_PHP_EMBED: ${{ contains(steps.formulae-detect.outputs.testing_formulae, 'unit-php') && 'php-embed,' || '' }}
+          NEED_UNIT: ${{ contains(steps.formulae-detect.outputs.testing_formulae, 'unit-') && 'unit,' || '' }}
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
This fixes a CI test problem when one of the formulas is updated, but
the main one, e.g. unit isnt.  Previous behaviour is to skip checks
which is erroneous since we don't check if the actual change is OK.